### PR TITLE
Spec update (Identifiers and Names)

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2,11 +2,14 @@
 
 |Field name|FHIR alignment|PDS alignment|Cardinality|Data Type & Format|Description & Reasoning|
 |----------|--------------|-------------|-----------|------------------|-----------------------|
-|`Identifier`|`Identifier.value`|`UNIQUE_REFERENCE` and `NHS_NO`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the person. In our case, this will be a person’s NHS number.|
+|`Identifier`|`Identifier`||1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the person.|
+|↳ `Identifier Value`|`Identifier.value`|`UNIQUE_REFERENCE`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the person. This will often be a person’s NHS number, but can also be another ID in case management systems. |
+|↳ `Identifier System`|`Identifier.system`||1 (MUST)|URI|A link to the system that the identifier adheres to. For example, an NHS number would have `https://fhir.nhs.uk/Id/nhs-number`.|
 |`Name`|`Patient.name (HumanName)`|-|1 (MUST)|**Object**|A container for the parts of a person's name. **Reasoning**: Storing name parts separately is essential for correct sorting, searching, and formal communication. Avoids a single "Full Name" field. |
-|↳ `Family Name`|`HumanName.family`|`FAMILY_NAME`|1 (MUST)|String(UTF-8)|The person's surname or family name. |
+|↳ `Family Name`|`HumanName.family`|`FAMILY_NAME`|1, Many (MUST)|String(UTF-8)|The person's surname or family name. |
 |↳ `Given Name(s)`|`HumanName.given`|`GIVEN_NAME`|1, Many (MUST)|String(UTF-8)|The person's first name, and any middle names. If multiple, they SHOULD be stored as separate entries if possible, or as a single space-separated string.|
 |↳ `Preferred Name(s)`|-|`OTHER_GIVEN_NAME`|0, Many|String(UTF-8)|Any preferred names used by the person. **Reasoning**: although FHIR does not have a field for preferred names, this information is too crucial for social care situations for it to not be considered in this specification. |
+|↳ `Use`|`HumanName.use`||0,1 (SHOULD)|Code:{usual, official, temp, nickname, anonymous, old, maiden}|The way this name object is used.|
 |`Date of Birth`|`Patient.birthDate`|`DATE_OF_BIRTH`|1 (MUST)|Date (ISO8601: `YYY-MM-DD`)|The person's date of birth. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|
 |`Address`|`Patient.address (Address)`|-|0, Many (SHOULD)|**Object**|The physical location where the person can be contacted. A person can have more than one address (e.g., home, work). A structured address is required for validation, mapping, and mail services. Avoids a single "Full Address" text block. |
 |↳ `Line 1`|`Address.line`|`ADDRESS_LINE1`|1 (MUST, if Address is present)|String(UTF-8)|Street address, c/o.|


### PR DESCRIPTION
As per issues #23 #34 (on identifiers) and #29 (on names), this content update:
- changes Identifier into an object that resembles the FHIR Identifier object
- adds elements within this object, namely Identifier.value, which takes a string ID value, and Identifier.system, which takes a namespace URI
- adds an element to the Name object, Use, which is directly aligned with FHIR's HumanName.use and enables (extensible) taxonomic tagging of how / why a name is being used.

These roughly line up with our conversations last week. The namespace URI is not amazing; the issue #23 did say that a majority of identifiers would be LA-specific ones, which are unlikely to have namespaces. But FHIR's identifier.system takes URI (and, importantly, no elements in the FHIR identifier object take strings, only codes or URI), and it's not difficult to get around (we just make a register of URIs that can be referenced, like FHIR do [here ](https://terminology.hl7.org/identifiers.html) where they've essentially made unofficial namespaces for different identifier systems like drivers licence numbers)

Having more than one identifier massively increases the changes of duplication in the data we're putting together. For a person with no NHS number, one LA might have them in their database with x identifier and another LA might have them with y; the same person, with the same name, same address, etc, might therefore be presented twice in the system. We'd have to really think about the way to de-dupe, or at least serve potential duplicates to data requests about persons.  