### PR TITLE
Updating spec with URLs for vocabs

### DIFF
--- a/person.json
+++ b/person.json
@@ -148,7 +148,7 @@
           "alignment": { "fhir": "Extension: UK Core PersonStatedGenderCode", "pds": "PERSON_STATED_GENDER_CODE" },
           "vocabulary": {
             "name": "PersonGenderCode",
-            "url": "#"
+            "url": "https://www.datadictionary.nhs.uk/data_elements/gender_identity_code.html"
           }
         },
         {
@@ -159,7 +159,7 @@
           "alignment": { "fhir": "Extension: UK Core PersonPhenotypicSex", "pds": "PERSON_PHENOTYPIC_SEX" },
           "vocabulary": {
             "name": "PersonPhenotypicSex",
-            "url": "#"
+            "url": "https://www.datadictionary.nhs.uk/data_elements/person_phenotypic_sex.html"
           }
         },
         {
@@ -210,7 +210,7 @@
               "name": "attribute",
               "type": "Code",
               "cardinality": "1..1",
-              "description": "A StatusCode to describe the type of status (eg. disability, free schoo meals).",
+              "description": "A StatusCode to describe the type of status (eg. disability, free school meals).",
               "vocabulary": {
                 "name": "StatusCode",
                 "url": "#"

--- a/person.json
+++ b/person.json
@@ -65,7 +65,11 @@
               "type": "Code",
               "cardinality": "0..1",
               "description": "How this name instance is used.",
-              "alignment": { "fhir": "HumanName.use" }
+              "alignment": { "fhir": "HumanName.use" },
+              "vocabulary": {
+                "name": "NameUseCode",
+                "url": "https://build.fhir.org/valueset-name-use.html"
+              }
             }
           ]
         },

--- a/person.json
+++ b/person.json
@@ -148,7 +148,7 @@
           "alignment": { "fhir": "Extension: UK Core PersonStatedGenderCode", "pds": "PERSON_STATED_GENDER_CODE" },
           "vocabulary": {
             "name": "PersonGenderCode",
-            "url": "https://www.datadictionary.nhs.uk/data_elements/gender_identity_code.html"
+            "url": "https://www.datadictionary.nhs.uk/data_elements/person_stated_gender_code.html"
           }
         },
         {

--- a/person.json
+++ b/person.json
@@ -98,7 +98,7 @@
         {
           "name": "Address",
           "type": "Object",
-          "cardinality": "0..*",
+          "cardinality": "1..*",
           "description": "Physical location(s) where the person can be contacted.",
           "alignment": { "fhir": "Patient.address (Address)" },
           "children": [

--- a/person.json
+++ b/person.json
@@ -217,7 +217,7 @@
               "description": "A StatusCode to describe the type of status (eg. disability, free school meals).",
               "vocabulary": {
                 "name": "StatusCode",
-                "url": "#"
+                "url": "https://socialcaredata.github.io/todo.html"
               }
             },
             {


### PR DESCRIPTION
The specification states that there are codes for certain categorical variables but doesn't link to these codes / vocabularies. Importantly, not all have actually been decided upon.

done so far:
* Gender: Codes for (a person's stated) gender were decided on initial construction of the person standard. They align with the NHS data dictionary's `GENDER IDENTITY CODE`
* Sex: Codes for phenotypic sex were proposed by the working group upon discussion of statutory requirements surrounding the collection of biological sex data. These align with the NHS data dictionary `PERSON PHENOTYPIC SEX` element
* Name use: the way a person's recorded name is used (eg. usual, nickname, maiden) can be described by the FHIR `name-use` value set

current todo: 
* date accuracy indicator : this was discussed by the working group to resemble the Australian FHIR extension. I need to find the link for that , but note that it didn't fit ISO8601 and the working group wanted it to.
* StatusCode : this is pending a working group discussion on statuses