### PR TITLE
Feature/connected person

### DIFF
--- a/person.json
+++ b/person.json
@@ -238,19 +238,168 @@
     },
     {
       "name": "ConnectedPerson",
-      "description": "Details of a person connected to the subject, where a full Person record is not available, appropriate, or yet matched.",
+      "description": "Details of a person connected to the subject, where a full Person record is not available, appropriate, or yet matched. This is mostly a copy of the Person record, without care-specific information and different cardinalities for all data fields",
       "fields": [
         {
-          "name": "Name",
-          "type": "String",
-          "cardinality": "1..1",
-          "description": "The known name or description of the person."
-        },
-        {
-          "name": "ContactInformation",
+          "name": "Identifier",
           "type": "Object",
           "cardinality": "0..*",
-          "description": "Available contact details.",
+          "description": "Unique identifiers (IDs) associated with the person.",
+          "children": [
+            {
+              "name": "value",
+              "type": "String",
+              "cardinality": "1..1",
+              "description": "A single unique identifier attached to the person (e.g., NHS number).",
+              "alignment": { "fhir": "Identifier.value", "pds": "UNIQUE_REFERENCE" }
+            },
+            {
+              "name": "system",
+              "type": "URI",
+              "cardinality": "1..1",
+              "description": "System that the identifier adheres to (e.g., https://fhir.nhs.uk/Id/nhs-number).",
+              "alignment": { "fhir": "Identifier.system" }
+            }
+          ]
+        },
+        {
+          "name": "Name",
+          "type": "Object",
+          "cardinality": "1..1",
+          "description": "Container for name parts.",
+          "children": [
+            {
+              "name": "familyName",
+              "type": "String",
+              "cardinality": "1..*",
+              "description": "Surname or family name.",
+              "alignment": { "fhir": "HumanName.family", "pds": "FAMILY_NAME" }
+            },
+            {
+              "name": "givenNames",
+              "type": "String",
+              "cardinality": "1..*",
+              "description": "First and any middle names.",
+              "alignment": { "fhir": "HumanName.given", "pds": "GIVEN_NAME" }
+            },
+            {
+              "name": "preferredNames",
+              "type": "String",
+              "cardinality": "0..*",
+              "description": "Any preferred names used by the person.",
+              "alignment": { "pds": "OTHER_GIVEN_NAME" }
+            },
+            {
+              "name": "use",
+              "type": "Code",
+              "cardinality": "0..1",
+              "description": "How this name instance is used.",
+              "alignment": { "fhir": "HumanName.use" },
+              "vocabulary": {
+                "name": "NameUseCode",
+                "url": "https://build.fhir.org/valueset-name-use.html"
+              }
+            }
+          ]
+        },
+        {
+          "name": "DateOfBirth",
+          "type": "Object",
+          "cardinality": "0..1",
+          "description": "The person's date of birth.",
+          "alignment": { "fhir": "Patient.birthDate", "pds": "DATE_OF_BIRTH" },
+          "children": [
+            {
+              "name": "date",
+              "type": "Date",
+              "cardinality": "0..1",
+              "description": "ISO8601 formatted date of birth (YYYY-MM-DD)."
+            },
+            {
+              "name": "accuracyIndicator",
+              "type": "Code",
+              "cardinality": "0..1",
+              "description": "Indicates which parts of the date are known to be accurate (A), estimated (E) or unknown (U).",
+              "alignment": { "fhir": "Extension:date-accuracy-indicator" }
+            }
+          ]
+        },
+        {
+          "name": "Address",
+          "type": "Object",
+          "cardinality": "0..*",
+          "description": "Physical location(s) where the person can be contacted.",
+          "alignment": { "fhir": "Patient.address (Address)" },
+          "children": [
+            {
+              "name": "line1",
+              "type": "String",
+              "cardinality": "1..1",
+              "description": "Street address, c/o.",
+              "alignment": { "fhir": "Address.line", "pds": "ADDRESS_LINE1" }
+            },
+            {
+              "name": "line2",
+              "type": "String",
+              "cardinality": "0..1",
+              "description": "Apartment, suite, unit, building, floor, etc.",
+              "alignment": { "fhir": "Address.line", "pds": "ADDRESS_LINE2" }
+            },
+            {
+              "name": "city",
+              "type": "String",
+              "cardinality": "1..1",
+              "description": "City, town, or village.",
+              "alignment": { "fhir": "Address.city" }
+            },
+            {
+              "name": "postcode",
+              "type": "String",
+              "cardinality": "1..1",
+              "description": "Postcode for address.",
+              "alignment": { "fhir": "Address.postalCode", "pds": "POSTCODE" }
+            },
+            {
+              "name": "UPRN",
+              "type": "Float16",
+              "cardinality": "0..1",
+              "description": "Unique Property Reference Number of the address."
+            },
+            {
+              "name": "USRN",
+              "type": "Float16",
+              "cardinality": "0..1",
+              "description": "Unique Street Reference Number of the address."
+            }
+          ]
+        },
+        {
+          "name": "Gender",
+          "type": "Code",
+          "cardinality": "0..1",
+          "description": "The person’s stated gender. This information does not pertain to biological sex.",
+          "alignment": { "fhir": "Extension: UK Core PersonStatedGenderCode", "pds": "PERSON_STATED_GENDER_CODE" },
+          "vocabulary": {
+            "name": "PersonGenderCode",
+            "url": "https://www.datadictionary.nhs.uk/data_elements/person_stated_gender_code.html"
+          }
+        },
+        {
+          "name": "SexCode",
+          "type": "Code",
+          "cardinality": "0..1",
+          "description": "Observed phenotypic sex, where recorded.",
+          "alignment": { "fhir": "Extension: UK Core PersonPhenotypicSex", "pds": "PERSON_PHENOTYPIC_SEX" },
+          "vocabulary": {
+            "name": "PersonPhenotypicSex",
+            "url": "https://www.datadictionary.nhs.uk/data_elements/person_phenotypic_sex.html"
+          }
+        },
+        {
+          "name": "PersonalContact",
+          "type": "Object",
+          "cardinality": "0..1",
+          "description": "Container for contact information.",
           "children": [
             {
               "name": "email",
@@ -270,7 +419,7 @@
           "name": "matchedPersonRef",
           "type": "Link",
           "cardinality": "0..1",
-          "description": "A reference (URI) to a formal Person record, if a match has been identified."
+          "description": "A reference (URI) to another ConnectedPerson or Person record, if a match has been identified."
         }
       ]
     }

--- a/person.json
+++ b/person.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "title": "Person Data Standard (Identification)",
-    "version": "0.2",
+    "version": "0.3",
     "status": "draft",
-    "effectiveDate": "2025-09-11",
-    "description": "Standardised data fields for identifying individuals in children’s and adult social care systems."
+    "effectiveDate": "2026-04-01",
+    "description": "Standardised data fields for identifying individuals in children’s and adult social care systems, including informal connections."
   },
   "entities": [
     {
@@ -176,7 +176,7 @@
               "name": "ref",
               "type": "Link",
               "cardinality": "1..1",
-              "description": "A reference (URI) to another Person record."
+              "description": "A reference (URI) to another Person or ConnectedPerson record."
             },
             {
               "name": "relationship",
@@ -233,6 +233,44 @@
               "description": "DateTime (ISO-8601) for end of the life event."
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "ConnectedPerson",
+      "description": "Details of a person connected to the subject, where a full Person record is not available, appropriate, or yet matched.",
+      "fields": [
+        {
+          "name": "Name",
+          "type": "String",
+          "cardinality": "1..1",
+          "description": "The known name or description of the person."
+        },
+        {
+          "name": "ContactInformation",
+          "type": "Object",
+          "cardinality": "0..*",
+          "description": "Available contact details.",
+          "children": [
+            {
+              "name": "email",
+              "type": "String",
+              "cardinality": "0..*",
+              "description": "Email address"
+            },
+            {
+              "name": "telephone",
+              "type": "Telephone Number",
+              "cardinality": "0..*",
+              "description": "Telephone Number"
+            }
+          ]
+        },
+        {
+          "name": "matchedPersonRef",
+          "type": "Link",
+          "cardinality": "0..1",
+          "description": "A reference (URI) to a formal Person record, if a match has been identified."
         }
       ]
     }

--- a/person.json
+++ b/person.json
@@ -233,6 +233,12 @@
               "description": "DateTime (ISO-8601) for end of the life event."
             }
           ]
+        },
+        {
+          "name": "matchedPersonRef",
+          "type": "Link",
+          "cardinality": "0..1",
+          "description": "A reference (URI) to another ConnectedPerson or Person record, if a match has been identified."
         }
       ]
     },


### PR DESCRIPTION
As per issue #60, adding a new object to describe connected people where full information is not known / collected. 

this object still has the full (non-care-related) breadth of the original Person, just with cardinalities that make everything optional. could be a GDPR problem.

this will require a change to the logical model page, i guess. 